### PR TITLE
Set image to Alpine based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
-FROM python:3.7
-RUN pip install esrally
+FROM python:3.7-alpine
+RUN apk add --update --no-cache build-base python-dev linux-headers openjdk8 git && \
+    pip install esrally
 ENTRYPOINT ["esrally"]


### PR DESCRIPTION
Decrease size from around `900MB` to `300MB`.
Also decrease number of security vulnerabilities by moving from Ubuntu to Alpine.