### PR TITLE
Specify correct docker registry name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Benchmark Elasticsearch cluster(s) on OKD (OpenShift).
 
 # Run as docker
 ```
-docker run -ti zenlab/esrally
+docker run -ti quay.io/zenlab/esrally
 ```
 
 # More info


### PR DESCRIPTION
Specify `quay.io` as the docker registry with the image.
Otherwise Docker defaults to `docker.io` which we don't have.