### PR TITLE
Revert "Set image to Alpine based image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-FROM python:3.7-alpine
-RUN apk add --update --no-cache build-base python-dev linux-headers openjdk8 git && \
-    pip install esrally
+FROM python:3.7
+RUN pip install esrally
 ENTRYPOINT ["esrally"]


### PR DESCRIPTION
Reverts zenaptix-lab/esrally#2

```
[ERROR] Cannot race. ('Neither JAVA11_HOME nor JAVA_HOME point to a JDK 11 installation.', None)
	Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/esrally/mechanic/mechanic.py", line 545, in receiveMsg_StartNodes
    msg.distribution, msg.external, msg.docker)
  File "/usr/local/lib/python3.7/site-packages/esrally/mechanic/mechanic.py", line 636, in create
    s = supplier.create(cfg, sources, distribution, build, challenge_root_path, car, plugins)
  File "/usr/local/lib/python3.7/site-packages/esrally/mechanic/supplier.py", line 27, in create
    java_home = _java_home(car)
  File "/usr/local/lib/python3.7/site-packages/esrally/mechanic/supplier.py", line 81, in _java_home
    _, path = jvm.resolve_path(int(build_jdk))
  File "/usr/local/lib/python3.7/site-packages/esrally/utils/jvm.py", line 94, in resolve_path
    return majors, _resolve_single_path(majors, sysprop_reader=sysprop_reader)
  File "/usr/local/lib/python3.7/site-packages/esrally/utils/jvm.py", line 139, in _resolve_single_path
    format(specific_env_var, generic_env_var, major))
esrally.exceptions.SystemSetupError: ('Neither JAVA11_HOME nor JAVA_HOME point to a JDK 11 installation.', None)
```